### PR TITLE
fixes TypeError, adds new endpoint, updates some comments

### DIFF
--- a/backend/test/views.py
+++ b/backend/test/views.py
@@ -373,7 +373,7 @@ def get_available_rooms(request):
     content = body['content']
     print(f'{content=}')
 
-    startTime = datetime.time(content[["startHour"], content["startMinute"]])
+    startTime = datetime.time(content["startHour"], content["startMinute"])
     endTime = datetime.time(content["endHour"], content["endMinute"])
 
     year, month, day = [int(x) for x in content['date'].split('-')]

--- a/backend/test/views.py
+++ b/backend/test/views.py
@@ -6,7 +6,6 @@ from rest_framework.decorators import api_view
 from . import models
 from .utils.fcns import *
 import datetime
-from datetime import datetime
 import random
 
 # Create your views here.

--- a/backend/test/views.py
+++ b/backend/test/views.py
@@ -60,7 +60,7 @@ def create_room(request):
 def create_reservation(request):
     """
     Requires roomId, libraryName, type, minCapacity, maxCapacity
-    noiseLevel, startHour, endHour, startMinute, endMinute
+    noiseLevel, date, startHour, endHour, startMinute, endMinute
     in request body 
     """
     body_unicode = request.body.decode('utf-8')

--- a/backend/test/views.py
+++ b/backend/test/views.py
@@ -141,7 +141,7 @@ def create_reservation(request):
 @api_view(['DELETE'])
 def delete_reservation(request):
     """
-    Requires startHour, endHour, startMinute, endMinute, and studentId
+    Requires date, startHour, endHour, startMinute, endMinute, and studentId
     in request body 
     """
     body_unicode = request.body.decode('utf-8')


### PR DESCRIPTION
- Removed the line "from datetime import datetime" because it creates TypeErrors in endpoints that were using datetime.time(). This line makes datetime.time() actually refer to datetime.datetime.time(), which is a method that returns time from a datetime.datetime object.
- added get_available_rooms endpoint that returns rooms that aren't reserved in a specified time span.
- included the date parameters in the comments describing 2 endpoints because they were left out